### PR TITLE
PHP notice when using Text::eol() and passing in a position that is out of range.

### DIFF
--- a/src/Text.php
+++ b/src/Text.php
@@ -54,7 +54,7 @@ class Text
             throw new Exception('Position is not int. ' . gettype($position));
         }
 
-        if ($this->eof()) {
+        if ($this->eof($position)) {
             throw new Exception('Index out of range. Position: ' . $position . '.');
         }
 

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -15,6 +15,15 @@ class TextTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RomanPitak\Nginx\Config\Exception
+     */    
+    public function testEolErr()
+    {
+        $text = new Text('This is a line for testing...');
+        $text->eol(30);
+    }
+
+    /**
+     * @expectedException \RomanPitak\Nginx\Config\Exception
      */
     public function testGetCharPosition()
     {


### PR DESCRIPTION
Can be reproduced by this example here:

```php
<?php

$text = new Text('This is a line for testing...');
if ($text->eol(30)) {
    // Do stuff...
}
```

This pull reuquest will fix that usecase.